### PR TITLE
Track data changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Default Values:
 * `hiddenAttributes`: []
 * `hiddenFromAggregators`: []
 * `hiddenFromDragDrop`: []
+* `valueFilter`: []
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -31,28 +31,26 @@ python usage.py
 
 The following parameters can be modified:
 - `id` *(string; optional)*: The ID used to identify this component in Dash callbacks
+- `aggregatorName` *(string; optional)*: Which aggregator is currently selected. E.g. Count, Sum, Average, etc.
+- `cols` *(list; optional)*: Which columns are currently in the column area
+- `colOrder` *(string; optional)*: The order in which column data is provided to the renderer, must be one
+of "key_a_to_z", "value_a_to_z", "value_z_to_a", ordering by value
+orders by column total
 - `data` *(list; optional)*: The input data
 - `hiddenAttributes` *(list; optional)*: contains attribute names to omit from the UI
 - `hiddenFromAggregators` *(list; optional)*: contains attribute names to omit from the aggregator arguments dropdowns
 - `hiddenFromDragDrop` *(list; optional)*: contains attribute names to omit from the drag'n'drop portion of the UI
 - `menuLimit` *(number; optional)*: maximum number of values to list in the double-click menu
-- `unusedOrientationCutoff` *(number; optional)*: If the attributes' names' combined length in characters exceeds this
-value then the unused attributes area will be shown vertically to the
-left of the UI instead of horizontally above it. 0 therefore means
-'always vertical', and Infinity means 'always horizontal'.
-
-The following props can be used as an input to callbacks, but can't be modified:
-- `cols` *(list; optional)*: Which columns are currently in the column area
-- `colOrder` *(string; optional)*: The order in which column data is provided to the renderer, must be one
-of "key_a_to_z", "value_a_to_z", "value_z_to_a", ordering by value
-orders by column total
+- `rendererName` *(string; optional)*: Which renderer is currently selected. E.g. Table, Line Chart, Scatter
 - `rows` *(list; optional)*: Which rows is currently inside the row area.
 - `rowOrder` *(string; optional)*: The order in which row data is provided to the renderer, must be one
 of "key_a_to_z", "value_a_to_z", "value_z_to_a", ordering by value
 orders by row total
-- `aggregatorName` *(string; optional)*: Which aggregator is currently selected. E.g. Count, Sum, Average, etc.
+- `unusedOrientationCutoff` *(number; optional)*: If the attributes' names' combined length in characters exceeds this
+value then the unused attributes area will be shown vertically to the
+left of the UI instead of horizontally above it. 0 therefore means
+'always vertical', and Infinity means 'always horizontal'.
 - `vals` *(list; optional)*: Attribute names used as arguments to aggregator (gets passed to aggregator generating function)
-- `rendererName` *(string; optional)*: Which renderer is currently selected. E.g. Table, Line Chart, Scatter
 - `valueFilter` *(dictionnary; optional)*: Object whose keys are attribute names and values are objects of attribute value-boolean pairs which denote records to include or exclude from computation and rendering; used to prepopulate the filter menus that appear on double-click
 
 Default Values:

--- a/dash_pivottable/PivotTable.py
+++ b/dash_pivottable/PivotTable.py
@@ -48,7 +48,7 @@ of "key_a_to_z", "value_a_to_z", "value_z_to_a", ordering by value
 orders by row total
 - aggregatorName (string; optional): Which aggregator is currently selected. E.g. Count, Sum, Average, etc.
 - vals (list; optional): Vals for the aggregator.
-- valueFilter (dict; optional): Value filter for each attibute name.
+- valueFilter (dict; optional): Value filter for each attribute name.
 - rendererName (string; optional): Which renderer is currently selected. E.g. Table, Line Chart, Scatter
 Chart, etc."""
     @_explicitize_args

--- a/dash_pivottable/metadata.json
+++ b/dash_pivottable/metadata.json
@@ -133,14 +133,22 @@
           "name": "array"
         },
         "required": false,
-        "description": "Vals for the aggregator."
+        "description": "Vals for the aggregator.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
       },
       "valueFilter": {
         "type": {
           "name": "object"
         },
         "required": false,
-        "description": "Value filter for each attibute name."
+        "description": "Value filter for each attribute name.",
+        "defaultValue": {
+          "value": "[]",
+          "computed": false
+        }
       },
       "rendererName": {
         "type": {

--- a/src/lib/components/PivotTable.react.js
+++ b/src/lib/components/PivotTable.react.js
@@ -35,7 +35,6 @@ const PlotlyRenderers = createPlotlyRenderers(Plot);
 export default class PivotTable extends Component {
     constructor(props) {
         super(props);
-        this.state = props;
         this.handleChange = this.handleChange.bind(this);
     }
 
@@ -46,7 +45,9 @@ export default class PivotTable extends Component {
           rows,
           rowOrder,
           aggregatorName,
-          rendererName
+          rendererName,
+          valueFilter,
+          vals,
         } = state;
 
         if (typeof this.props.setProps === 'function') {
@@ -56,7 +57,9 @@ export default class PivotTable extends Component {
                 rows,
                 rowOrder,
                 aggregatorName,
-                rendererName
+                rendererName,
+                valueFilter,
+                vals,
             });
         }
 
@@ -70,7 +73,9 @@ export default class PivotTable extends Component {
             hiddenFromAggregators,
             hiddenFromDragDrop,
             menuLimit,
-            unusedOrientationCutoff
+            unusedOrientationCutoff,
+            valueFilter,
+            vals,
         } = this.props;
 
         return (
@@ -83,7 +88,9 @@ export default class PivotTable extends Component {
                 hiddenFromDragDrop={hiddenFromDragDrop}
                 menuLimit={menuLimit}
                 unusedOrientationCutoff={unusedOrientationCutoff}
-                {...this.state}
+                valueFilter={valueFilter}
+                vals={vals}
+                {...this.props}
             />
         );
     }
@@ -94,7 +101,9 @@ PivotTable.defaultProps = {
     unusedOrientationCutoff: 85,
     hiddenAttributes: [],
     hiddenFromAggregators: [],
-    hiddenFromDragDrop: []
+    hiddenFromDragDrop: [], 
+    valueFilter: [],
+    vals: [],
 };
 
 PivotTable.propTypes = {
@@ -181,7 +190,7 @@ PivotTable.propTypes = {
     vals: PropTypes.array,
 
     /**
-     * Value filter for each attibute name.
+     * Value filter for each attribute name.
      */
     valueFilter: PropTypes.object,
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -18,10 +18,10 @@ def test_callbacks(dash_duo):
     app = import_app('usage')
     dash_duo.start_server(app)
 
-    for prop in expected:
+    for prop, expected_value in expected.items():
         try:
             dash_duo.wait_for_text_to_equal(
-                f'#{prop}', expected[prop], timeout=4
+                f'#{prop}', expected_value, timeout=4
             )
-        except TimeoutException:
-            raise Exception(f"Attribute '{prop}' failed to render correctly.")
+        except TimeoutException as exc:
+            raise Exception(f"Attribute '{prop}' failed to render correctly.") from exc

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -14,6 +14,7 @@ def test_callbacks(dash_duo):
         'aggregator': 'Average',
         'renderer': 'Grouped Column Chart',
         'data_length': 'Data length: 245',
+        'value_filter': "{'Day of Week': {'Thursday': False}}",
     }
 
     app = import_app('usage')

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -13,6 +13,7 @@ def test_callbacks(dash_duo):
         'col_order': 'key_a_to_z',
         'aggregator': 'Average',
         'renderer': 'Grouped Column Chart',
+        'data_length': 'Data length: 245',
     }
 
     app = import_app('usage')

--- a/usage.py
+++ b/usage.py
@@ -21,6 +21,7 @@ app.layout = html.Div([
         vals=["Total Bill"],
         valueFilter={'Day of Week': {'Thursday': False}}
     ),
+    html.Button('Toggle data', id='toggle-data-button', n_clicks=0),
     html.Div(
         id='output'
     )
@@ -33,8 +34,9 @@ app.layout = html.Div([
                Input('table', 'rowOrder'),
                Input('table', 'colOrder'),
                Input('table', 'aggregatorName'),
-               Input('table', 'rendererName')])
-def display_props(cols, rows, row_order, col_order, aggregator, renderer):
+               Input('table', 'rendererName'),
+               Input('table', 'data')])
+def display_props(cols, rows, row_order, col_order, aggregator, renderer, data_input):
     return [
         html.P(str(cols), id='columns'),
         html.P(str(rows), id='rows'),
@@ -42,7 +44,17 @@ def display_props(cols, rows, row_order, col_order, aggregator, renderer):
         html.P(str(col_order), id='col_order'),
         html.P(str(aggregator), id='aggregator'),
         html.P(str(renderer), id='renderer'),
+        html.P(f'Data length: {len(data_input)}', id='data_length'),
     ]
+
+
+@app.callback(Output('table', 'data'),
+              [Input('toggle-data-button', 'n_clicks')],
+              prevent_initial_call=True)
+def toggle_data(n_clicks):
+    if n_clicks % 2 == 0:
+        return data
+    return data[:len(data)//2]
 
 
 if __name__ == '__main__':

--- a/usage.py
+++ b/usage.py
@@ -1,5 +1,5 @@
 import dash
-from dash.dependencies import Input, Output
+from dash.dependencies import Input, Output, State
 import dash_html_components as html
 import dash_pivottable
 
@@ -7,6 +7,9 @@ from data import data
 
 app = dash.Dash(__name__)
 app.title = 'My Dash example'
+
+VALUE_FILTER_DEFAULT = {'Day of Week': {'Thursday': False}}
+VALUE_FILTER_ALT = {'Day of Week': {'Friday': False}}
 
 app.layout = html.Div([
     dash_pivottable.PivotTable(
@@ -19,9 +22,13 @@ app.layout = html.Div([
         rendererName="Grouped Column Chart",
         aggregatorName="Average",
         vals=["Total Bill"],
-        valueFilter={'Day of Week': {'Thursday': False}}
+        valueFilter=VALUE_FILTER_DEFAULT,
     ),
     html.Button('Toggle data', id='toggle-data-button', n_clicks=0),
+    html.Button('Toggle filter', id='toggle-filter-button', n_clicks=0),
+    html.Button('Toggle rows and cols', id='toggle-rows-cols-button', n_clicks=0),
+    html.Button('Toggle order', id='toggle-order-button', n_clicks=0),
+    html.Button('Toggle analysis', id='toggle-analysis-button', n_clicks=0),
     html.Div(
         id='output'
     )
@@ -35,8 +42,9 @@ app.layout = html.Div([
                Input('table', 'colOrder'),
                Input('table', 'aggregatorName'),
                Input('table', 'rendererName'),
-               Input('table', 'data')])
-def display_props(cols, rows, row_order, col_order, aggregator, renderer, data_input):
+               Input('table', 'data'),
+               Input('table', 'valueFilter')])
+def display_props(cols, rows, row_order, col_order, aggregator, renderer, data_input, value_filter):
     return [
         html.P(str(cols), id='columns'),
         html.P(str(rows), id='rows'),
@@ -44,6 +52,7 @@ def display_props(cols, rows, row_order, col_order, aggregator, renderer, data_i
         html.P(str(col_order), id='col_order'),
         html.P(str(aggregator), id='aggregator'),
         html.P(str(renderer), id='renderer'),
+        html.P(str(value_filter), id='value_filter'),
         html.P(f'Data length: {len(data_input)}', id='data_length'),
     ]
 
@@ -55,6 +64,56 @@ def toggle_data(n_clicks):
     if n_clicks % 2 == 0:
         return data
     return data[:len(data)//2]
+
+
+@app.callback(Output('table', 'valueFilter'),
+              [Input('toggle-filter-button', 'n_clicks')],
+              prevent_initial_call=True)
+def toggle_filter(n_clicks):
+    if n_clicks % 2 == 0:
+        return VALUE_FILTER_DEFAULT
+    return VALUE_FILTER_ALT
+
+
+@app.callback([Output('table', 'rows'),
+               Output('table', 'cols')],
+              [Input('toggle-rows-cols-button', 'n_clicks')],
+              [State('table', 'rows'),
+               State('table', 'cols')],
+              prevent_initial_call=True)
+def toggle_rows_cols(_n_clicks, rows, cols):
+    return cols, rows
+
+
+@app.callback([Output('table', 'rowOrder'),
+               Output('table', 'colOrder')],
+              [Input('toggle-order-button', 'n_clicks')],
+              [State('table', 'rowOrder'),
+               State('table', 'colOrder')],
+              prevent_initial_call=True)
+def toggle_order(_n_clicks, row_order, col_order):
+
+    def switch_order(order):
+        if order == 'key_a_to_z':
+            return 'value_z_to_a'
+        return 'key_a_to_z'
+
+    return switch_order(row_order), switch_order(col_order)
+
+
+@app.callback([Output('table', 'rendererName'),
+               Output('table', 'aggregatorName'),
+               Output('table', 'vals')],
+              [Input('toggle-analysis-button', 'n_clicks')],
+              [State('table', 'rendererName'),
+               State('table', 'aggregatorName'),
+               State('table', 'vals')],
+              prevent_initial_call=True)
+def toggle_analysis(_n_clicks, renderer_name, aggregator_name, vals):
+    renderer_name = 'Grouped Column Chart' if renderer_name == 'Line Chart' else 'Line Chart'
+    aggregator_name = 'Average' if aggregator_name == 'Sum' else 'Sum'
+    vals = ['Total Bill'] if vals == ['Party Size'] else ['Party Size']
+    return renderer_name, aggregator_name, vals
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## About
This PR fixes https://github.com/plotly/dash-pivottable/issues/10 and as a bonus side-affect makes all of the previously read-only properties of the `dash_pivottable.PivotTable` writeable.

## Description of changes 

- The first commit fixes some pre-existing pylint issues
- The second commit updates `usage.py` to demonstrate that changes to `data` are not being picked up by the pivot table.
- The third commit fixes that by using `props` values and not writing to `state` as inspired by the following console warning emitted when loading `usage.py`:
```
Warning: PivotTable: It is not recommended to assign props directly to state because updates to props won't be reflected in state. In most cases, it is better to use props directly.
    in PivotTable (created by CheckedComponent)
    in CheckedComponent (created by BaseTreeContainer)
    in ComponentErrorBoundary (created by BaseTreeContainer)
    in BaseTreeContainer (created by Context.Consumer)
    in Unknown (created by BaseTreeContainer)
    in div (created by u)
    in u (created by CheckedComponent)
    in CheckedComponent (created by BaseTreeContainer)
    in ComponentErrorBoundary (created by BaseTreeContainer)
    in BaseTreeContainer (created by Context.Consumer)
    in Unknown (created by UnconnectedContainer)
    in div (created by UnconnectedGlobalErrorContainer)
    in div (created by GlobalErrorOverlay)
    in div (created by GlobalErrorOverlay)
    in GlobalErrorOverlay (created by DebugMenu)
    in div (created by DebugMenu)
    in DebugMenu (created by UnconnectedGlobalErrorContainer)
    in div (created by UnconnectedGlobalErrorContainer)
    in UnconnectedGlobalErrorContainer (created by withRadiumContexts(UnconnectedGlobalErrorContainer))
    in withRadiumContexts(UnconnectedGlobalErrorContainer) (created by ConnectFunction)
    in ConnectFunction (created by UnconnectedContainer)
    in UnconnectedContainer (created by ConnectFunction)
    in ConnectFunction (created by UnconnectedAppContainer)
    in UnconnectedAppContainer (created by ConnectFunction)
    in ConnectFunction (created by AppProvider)
    in Provider (created by AppProvider)
    in AppProvider
```
- The fourth commit the readme to say that changes to all the previous read-only only pivottable values can now be written to whilst also updating `usage.py` to demonstrate that is indeed now possible.

## Pre-Merge checklist
- [ ] The project was correctly built with `npm run build:all`.
- [ ] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash Pivottable core contributor.


## Reference Issues
Fixes #10 